### PR TITLE
fix buildNestedTree

### DIFF
--- a/src/NestedSetModel.php
+++ b/src/NestedSetModel.php
@@ -342,7 +342,7 @@ trait NestedSetModel
 
         $getChildrenFunc = function ($nodes) use (&$getChildrenFunc, $groupNodes) {
             foreach ($nodes as $node) {
-                $node->setRelation('children', collect($groupNodes[$node->{static::primaryColumn()}] ?? []));
+                $node->children = $groupNodes[$node->{static::primaryColumn()}] ?? [];
                 $getChildrenFunc($node->children);
             }
         };
@@ -369,7 +369,7 @@ trait NestedSetModel
                 return;
             }
 
-            $children = $node->children->all();
+            $children = $node->children;
             $children[0]->{static::depthColumn()} = $node->{static::depthColumn()} + 1;
             $children[0]->{static::leftColumn()}  = $node->{static::leftColumn()} + 1;
             $fixPositionFunc($children[0]);


### PR DESCRIPTION
Việc sử dụng `setRelation` làm cho `buildNestedTree` bị phụ thuộc vào việc dữ liệu truyền vào phải là 1 danh sách của Eloquent model, loại bỏ xử lý trên để `buildNestedTree` flexible hơn

![image](https://user-images.githubusercontent.com/105692913/195497069-20a63409-13cf-404e-8faf-66940e7e31f9.png)

